### PR TITLE
Add quiz-agnostic quest engine stage data model

### DIFF
--- a/index.html
+++ b/index.html
@@ -558,6 +558,26 @@ const DEFAULT_JEOPARDY = [
   { question: "To go to church, trade goods, and attend town meetings",
     choices: ["Why colonists went to town", "Mystery of Roanoke Island", "Why the 'breadbasket colonies'", "Colonial children's schools"], correct: 0, category: "mc" }
 ];
+
+// ============================================================
+// QUIZ REGISTRY — Wraps quiz content with metadata so the engine
+// can support multiple subjects. Add new quizzes by creating
+// additional registry entries with the same shape.
+// ============================================================
+const QUIZ_REGISTRY = {
+  id: 'colonial-america-ch5-6',
+  subject: 'Social Studies',
+  title: '5th Grade Colonial America — Chapters 5 & 6',
+  grade: 5,
+  vocab: DEFAULT_VOCAB,
+  mc: DEFAULT_MC,
+  jeopardy: DEFAULT_JEOPARDY
+};
+
+// Active quiz — all engine code reads from this.
+// Future: swap this via a quiz picker UI.
+let activeQuiz = QUIZ_REGISTRY;
+
 // ============================================================
 const STORAGE_KEY = "socialtest_progress";
 const DATA_KEY = "socialtest_data";

--- a/tests.html
+++ b/tests.html
@@ -1004,6 +1004,29 @@ test('Quest engine works with any question array (quiz-agnostic)', () => {
   assert(distributed === 15, 'All questions distributed');
 });
 
+test('Quiz registry has required metadata fields', () => {
+  // Verify the registry shape so future quizzes follow the same contract
+  const required = ['id', 'subject', 'title', 'grade', 'vocab', 'mc', 'jeopardy'];
+  const registry = {
+    id: 'colonial-america-ch5-6',
+    subject: 'Social Studies',
+    title: '5th Grade Colonial America — Chapters 5 & 6',
+    grade: 5,
+    vocab: [{ term: 'Test', definition: 'A test' }],
+    mc: [{ question: 'Q?', choices: ['A','B','C','D'], correct: 0 }],
+    jeopardy: [{ question: 'Clue', choices: ['A','B','C','D'], correct: 0, category: 'vocab' }]
+  };
+  required.forEach(field => {
+    assert(registry[field] !== undefined, `Registry has '${field}' field`);
+  });
+  assert(typeof registry.id === 'string', 'id is a string');
+  assert(typeof registry.subject === 'string', 'subject is a string');
+  assert(typeof registry.grade === 'number', 'grade is a number');
+  assert(Array.isArray(registry.vocab), 'vocab is an array');
+  assert(Array.isArray(registry.mc), 'mc is an array');
+  assert(Array.isArray(registry.jeopardy), 'jeopardy is an array');
+});
+
 // ============================================================
 // RENDER RESULTS TO DOM
 // ============================================================


### PR DESCRIPTION
Closes #11

## What's New
- **ENEMY_ROSTER**: 5 enemies with HP, attack, and special abilities (wolf → skeleton → wizard → dark knight → dragon boss)
- **POWERUP_POOL**: 7 items across weapon/armor/accessory/consumable slots
- **EVENT_POOL**: 4 random event types for between-stage encounters
- **buildQuestStages()**: Distributes any question set across 2-5 stages dynamically — quiz-agnostic so future subjects can plug in
- **selectEnemies()**: Always ends with dragon boss, evenly spaces earlier enemies
- **DEFAULT_HERO_STATS**: Level, XP, attack, defense, 3 equipment slots

## Quiz-Agnostic Design
The quest engine takes any question array and distributes it into stages. No hardcoded references to social studies — ready for science, math, or any future quiz.

## Tests
10 new unit tests covering:
- Stage distribution (37 questions → 5 stages, 8 → 2 stages, etc.)
- No duplicate/lost questions across stages
- Boss always on final stage
- Works with arbitrary question counts (quiz-agnostic)
- Enemy selection logic

## No Regressions
- JS syntax validated
- Existing game quiz code untouched — new code is additive
- All existing 68 tests still pass