### PR TITLE
Refactor game state into stage-aware quest state machine

### DIFF
--- a/index.html
+++ b/index.html
@@ -909,6 +909,13 @@ function applyPowerup(powerup) {
   const hero = questState.hero;
   const eff = powerup.effect;
 
+  // Remove old equipment bonuses before applying new ones
+  if (powerup.slot !== 'consumable' && hero.equipment[powerup.slot]) {
+    const oldEff = hero.equipment[powerup.slot].effect;
+    if (oldEff.atk) hero.atk -= oldEff.atk;
+    if (oldEff.xpBonus) hero.xpBonus = Math.max(0, (hero.xpBonus || 0) - oldEff.xpBonus);
+  }
+
   if (eff.atk) hero.atk += eff.atk;
   if (eff.healHearts) {
     heroHP = Math.min(heroHP + eff.healHearts * 2, heroMaxHP);

--- a/tests.html
+++ b/tests.html
@@ -1130,6 +1130,24 @@ test('Equipment applies stat modifiers correctly', () => {
   assert(hero.equipment.weapon.id === 'sharp-sword', 'Sword equipped');
 });
 
+test('Replacing equipment removes old stat bonuses', () => {
+  const hero = { atk: 1, xpBonus: 0, equipment: { weapon: null, armor: null, accessory: null } };
+  const sword1 = { id: 'sharp-sword', slot: 'weapon', effect: { atk: 1 } };
+  const sword2 = { id: 'sharp-sword', slot: 'weapon', effect: { atk: 1 } };
+
+  // Equip first sword
+  hero.atk += sword1.effect.atk;
+  hero.equipment.weapon = sword1;
+  assert(hero.atk === 2, 'First sword: atk = 2');
+
+  // Replace with second sword — must remove old bonus first
+  const oldEff = hero.equipment.weapon.effect;
+  if (oldEff.atk) hero.atk -= oldEff.atk;
+  hero.atk += sword2.effect.atk;
+  hero.equipment.weapon = sword2;
+  assert(hero.atk === 2, `After replacement: expected 2, got ${hero.atk} (no stacking)`);
+});
+
 test('getEquipmentEffect finds effects across slots', () => {
   const eq = {
     weapon: { effect: { atk: 1 } },


### PR DESCRIPTION
Closes #12

## What's New

### Quest State Machine
- \questState\ object wraps all multi-stage state (phase, stages, hero stats, per-stage answers, XP, equipment)
- **Phase flow**: STAGE_INTRO → QUESTIONS → STAGE_CLEAR → EVENT → DRAFT → next STAGE_INTRO (or BOSS_INTRO → VICTORY/DEFEAT)
- \dvanceQuestPhase()\ drives the state machine, \dvanceToNextStage()\ resets per-stage state

### Hero System
- \startQuest()\ initializes hero with \DEFAULT_HERO_STATS\
- \wardQuestXP()\ — XP gain + level-up (atk+1, maxHP+2, 1.4x XP curve)
- \pplyPowerup()\ — equips items to weapon/armor/accessory slots
- \pplyEventEffect()\ — handles random event outcomes (heal, skip draft, etc.)
- \getEquipmentEffect()\ — searches across all equipped items for a specific effect

### Persistence
- \questState\ added to save/load — backward compatible with old saves

## Tests
9 new unit tests covering: initialization, phase transitions, victory/defeat states, XP math, equipment effects, draft randomization, event healing, save/restore round-trip.

## No Regressions
- All existing game quiz code untouched — new state machine is additive
- JS syntax validated
- Old save format still loads correctly (questState defaults to null)